### PR TITLE
Workaround erlang:get_stacktrace/0 deprecation in OTP 21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore rebar3 build directory
+/_build/

--- a/rebar.config
+++ b/rebar.config
@@ -8,4 +8,14 @@
            ,{plt_apps, top_level_deps}
            ,{plt_prefix, "director"}]}.
 
+{deps, [
+    % Handle stacktrace changes in OTP 21
+    {stacktrace_compat, "1.0.1"}
+]}.
+
+{erl_opts, [
+    % stacktrace_compat parse transform
+    {parse_transform, stacktrace_transform}
+]}.
+
 %%{plugins, [rebar3_hex]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,6 @@
+{"1.1.0",
+[{<<"stacktrace_compat">>,{pkg,<<"stacktrace_compat">>,<<"1.0.1">>},0}]}.
+[
+{pkg_hash,[
+ {<<"stacktrace_compat">>, <<"9769D80AE7B09E0BE405927561127D410FEC7A340E52E9286CE1F73DD1639095">>}]}
+].


### PR DESCRIPTION
This PR works around the deprecation of `erlang:get_stacktrace/0` in OTP 21 while remaining compatible with OTP versions less than 21 by using the [`stacktrace_compat`](https://github.com/g-andrade/stacktrace_compat) parse transform library.
